### PR TITLE
two new functions: metaboliteDilutionRate and specificMedia

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/CometsParameters.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/CometsParameters.java
@@ -62,7 +62,7 @@ public class CometsParameters implements CometsConstants
 //	}
 	
 	private double timeStep = 1,				// hours
-				   deathRate = 0.1,				// percent per time point
+				   deathRate = 0.1,				// fraction per hour
 				   activateRate = 0.001,        // 1/hours
 				   maxSpaceBiomass = 10,		// grams
 				   minSpaceBiomass = 1e-10,		// grams
@@ -73,7 +73,8 @@ public class CometsParameters implements CometsConstants
 				   dilFactor = 1e-2,
 				   dilTime = 12,				// hours
 				   mutRate = 1e-9,				// per genome and cycle
-				   addRate = 1e-9;				// per genome and cycle	
+				   addRate = 1e-9,				// per genome and cycle	
+				   metaboliteDilutionRate = 0.0;// fraction per hour
 	
 	private boolean isCommandLine = false,
 					showGraphics = true,
@@ -168,6 +169,7 @@ public class CometsParameters implements CometsConstants
 		setActivateRate(((Double)paramValues.get("activaterate")).doubleValue());
 		setMutRate(((Double)paramValues.get("mutrate")).doubleValue());
 		setAddRate(((Double)paramValues.get("addrate")).doubleValue());
+		setMetaboliteDilutionRate(((Double)paramValues.get("metabolitedilutionrate")).doubleValue());
 
 		setCommandLineOnly(((Boolean)paramValues.get("iscommandline")).booleanValue());
 		showGraphics(((Boolean)paramValues.get("showgraphics")).booleanValue());
@@ -334,6 +336,9 @@ public class CometsParameters implements CometsConstants
 
 		paramValues.put("evolution", new Boolean(evolution));
 		paramTypes.put("evolution", ParameterType.BOOLEAN);
+		
+		paramValues.put("metabolitedilutionrate", new Double(metaboliteDilutionRate));
+		paramTypes.put("metabolitedilutionrate", ParameterType.DOUBLE);
 
 		//paramValues.put("seed", new Long(seed));
 		//paramTypes.put("seed", ParameterType.LONG);
@@ -543,6 +548,39 @@ public class CometsParameters implements CometsConstants
 	{
 		if (d >= 0)
 			dilTime = d;
+	}
+	
+	/**
+	 * @return the metabolite dilution rate
+	 * chacon
+	 */
+	public double getMetaboliteDilutionRate()
+	{
+		return metaboliteDilutionRate;
+	}
+	
+	private void checkMetaboliteDilutionRate(double rate) throws NumberFormatException
+	{
+		if (rate < 0 | rate > 1){
+			throw new NumberFormatException();
+		}
+	}
+	/**
+	 * Sets the metaboliteDilutionRate
+	 * @param rate
+	 */
+	public void setMetaboliteDilutionRate(double rate)
+	{
+		try
+		{
+			checkMetaboliteDilutionRate(rate);
+		}
+		catch(NumberFormatException e)
+		{
+			throw new NumberFormatException("metaboliteDilutionRate must be between 0-1");
+		}
+		metaboliteDilutionRate = rate;
+		System.out.println("itgotset");
 	}
 
 	
@@ -1303,6 +1341,7 @@ public class CometsParameters implements CometsConstants
 		s += "maxSpaceBiomassConc = " + maxSpaceBiomass + "\n";
 		s += "spaceWidth = " + spaceWidth + "\n";
 //		s += "numRunThreads = " + numRunThreads + "\n";
+		s += "metaboliteDilutionRate = " + metaboliteDilutionRate + "\n";
 
 		s += "isCommandLine = " + isCommandLine + "\n";
 		s += "showGraphics = " + showGraphics + "\n";

--- a/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
@@ -978,7 +978,10 @@ public abstract class World2D implements CometsConstants, IWorld
 	{
 		return mediaRefresh;
 	}
-	
+	/**
+	 * dilutes the media world-wide by a global dilution coefficient, which is supplied
+	 * in the parameters file as metaboliteDilution
+	 */
 	public void applyMetaboliteDilution()
 	{
 		double metaboliteDilutionRate = cParams.getMetaboliteDilutionRate();

--- a/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
@@ -977,7 +977,29 @@ public abstract class World2D implements CometsConstants, IWorld
 	public double[] getMediaRefreshAmount()
 	{
 		return mediaRefresh;
-	}	
+	}
+	
+	public void applyMetaboliteDilution()
+	{
+		double metaboliteDilutionRate = cParams.getMetaboliteDilutionRate();
+		if (metaboliteDilutionRate == 0.0)
+		{
+			return; // don't bother wasting cpu if no dilution applied
+		}
+		double dt = cParams.getTimeStep();
+		for (int i = 0; i < numCols; i++)
+		{
+			for (int j = 0; j < numRows; j++)
+			{
+				for (int k = 0; k < numMedia; k++)
+				{
+					media[i][j][k] -= media[i][j][k] * metaboliteDilutionRate * dt;
+					if (media[i][j][k] < 0)
+						media[i][j][k] = 0;
+				}
+			}
+		}
+	}
 	
 	/**
 	 * Puts the given <code>Cell</code> into the world at (x, y)

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAParameters.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAParameters.java
@@ -141,6 +141,7 @@ public class FBAParameters implements PackageParameters
 	writeBiomassLog,
 	writeVelocityLog,
 	writeTotalBiomassLog,
+	writeSpecificMediaLog,
 	writeMatFile,
 	useLogNameTimeStamp,
 	randomOrder = true, //shuffle the order each model in a cell is run
@@ -153,6 +154,8 @@ public class FBAParameters implements PackageParameters
 	biomassLogName,
 	velocityLogName,
 	totalBiomassLogName,
+	specificMediaLogName,
+	specificMedia, // different fron specificMediaLogName.  This string stores the names of the extracelluar mets t log
 	matFileName;
 
 	private String manifestFileName = "COMETS_manifest.txt";
@@ -165,6 +168,7 @@ public class FBAParameters implements PackageParameters
 			biomassLogRate = 1,
 			velocityLogRate = 1,
 			totalBiomassLogRate = 1,
+			specificMediaLogRate = 1,
 			numExRxnSubsteps = 12, //12 chosen as default so if timestep is 1h, minimum substep is < 1sec
 			matFileRate = 1;
 
@@ -212,6 +216,7 @@ public class FBAParameters implements PackageParameters
 		writeBiomassLog = false;
 		writeVelocityLog = false;
 		writeTotalBiomassLog = false;
+		writeSpecificMediaLog = false;
 		writeMatFile = false;
 		useLogNameTimeStamp = true;
 
@@ -221,6 +226,8 @@ public class FBAParameters implements PackageParameters
 		velocityLogName = "velocity_log.txt";
 		matFileName = "comets_log.mat";
 		totalBiomassLogName = "total_biomass_log.txt";
+		specificMediaLogName = "specific_media_log.txt";
+		specificMedia = "";
 
 		paramValues = new HashMap<String, Object>();
 		paramTypes = new HashMap<String, ParameterType>();
@@ -254,6 +261,9 @@ public class FBAParameters implements PackageParameters
 		
 		paramValues.put("writetotalbiomasslog", new Boolean(writeTotalBiomassLog));
 		paramTypes.put("writetotalbiomasslog", ParameterType.BOOLEAN);
+		
+		paramValues.put("writespecificmedialog", new Boolean(writeSpecificMediaLog));
+		paramTypes.put("writespecificmedialog", ParameterType.BOOLEAN);
 
 		paramValues.put("writematfile", new Boolean(writeMatFile));
 		paramTypes.put("writematfile", ParameterType.BOOLEAN);
@@ -275,6 +285,12 @@ public class FBAParameters implements PackageParameters
 		
 		paramValues.put("totalbiomasslogname", totalBiomassLogName);
 		paramTypes.put("totalbiomasslogname", ParameterType.STRING);
+		
+		paramValues.put("specificmedialogname", specificMediaLogName); 
+		paramTypes.put("specificmedialogname", ParameterType.STRING);
+		
+		paramValues.put("specificmedia", specificMedia); 
+		paramTypes.put("specificmedia", ParameterType.STRING);
 
 		paramValues.put("matfilename", matFileName);
 		paramTypes.put("matfilename", ParameterType.STRING);
@@ -293,6 +309,9 @@ public class FBAParameters implements PackageParameters
 
 		paramValues.put("numrunthreads", new Integer(numRunThreads));
 		paramTypes.put("numrunthreads", ParameterType.INT);
+		
+		paramValues.put("specificmedialograte", new Integer(specificMediaLogRate)); 
+		paramTypes.put("specificmedialograte", ParameterType.INT);
 
 		paramValues.put("growthdiffrate", new Double(growthDiffRate));
 		paramTypes.put("growthdiffrate", ParameterType.DOUBLE);
@@ -369,6 +388,7 @@ public class FBAParameters implements PackageParameters
 		writeBiomassLog(((Boolean)paramValues.get("writebiomasslog")).booleanValue());
 		writeVelocityLog(((Boolean)paramValues.get("writevelocitylog")).booleanValue());
 		writeTotalBiomassLog(((Boolean)paramValues.get("writetotalbiomasslog")).booleanValue());
+		writeSpecificMediaLog(((Boolean)paramValues.get("writespecificmedialog")).booleanValue());
 		writeMatFile(((Boolean)paramValues.get("writematfile")).booleanValue());
 		useLogNameTimeStamp(((Boolean)paramValues.get("uselognametimestamp")).booleanValue());
 		setFluxLogName((String)paramValues.get("fluxlogname"));
@@ -376,6 +396,8 @@ public class FBAParameters implements PackageParameters
 		setBiomassLogName((String)paramValues.get("biomasslogname"));
 		setVelocityLogName((String)paramValues.get("velocitylogname"));
 		setTotalBiomassLogName((String)paramValues.get("totalbiomasslogname"));
+		setSpecificMediaLogName((String)paramValues.get("specificmedialogname"));
+		setSpecificMedia((String)paramValues.get("specificmedia"));
 		setMatFileName((String)paramValues.get("matfilename"));
 		setRandomOrder(((Boolean)paramValues.get("randomorder")).booleanValue());
 		setCostlyGenome(((Boolean)paramValues.get("costlygenome")).booleanValue());		
@@ -432,6 +454,7 @@ public class FBAParameters implements PackageParameters
 		setBiomassLogRate(((Integer)paramValues.get("biomasslograte")).intValue());
 		setVelocityLogRate(((Integer)paramValues.get("velocitylograte")).intValue());
 		setTotalBiomassLogRate(((Integer)paramValues.get("totalbiomasslograte")).intValue());
+		setSpecificMediaLogRate(((Integer)paramValues.get("specificmedialograte")).intValue());
 		setMatFileRate(((Integer)paramValues.get("matfilerate")).intValue());
 		setNumDiffusionsPerStep(((Integer)paramValues.get("numdiffperstep")).intValue());
 		setDefaultDiffusionConstant(((Double)paramValues.get("defaultdiffconst")).doubleValue());
@@ -658,6 +681,25 @@ public class FBAParameters implements PackageParameters
 		if (i > 0)
 			totalBiomassLogRate = i;
 	}
+	
+	/**
+	 * Sets the number of steps that occur between every specific media log write. If <code>i</code>
+	 * is less than 1, nothing is changed.
+	 * @param i
+	 */
+	public void setSpecificMediaLogRate(int i)
+	{
+		if (i > 0)
+			specificMediaLogRate = i;
+	}
+	
+	/**
+	 * @return the number of simulation steps that occur between every specific media log write
+	 */
+	public int getSpecificMediaLogRate() 
+	{ 
+		return specificMediaLogRate; 
+	}	
 
 	/**
 	 * @return the number of simulation steps that occur between every .mat file log write
@@ -970,6 +1012,22 @@ public class FBAParameters implements PackageParameters
 	{
 		return writeMediaLog; 
 	}
+	/**
+	 * @param b if true, write a specific media log
+	 * 
+	 */
+	public void writeSpecificMediaLog(boolean b)
+	{
+		writeSpecificMediaLog = b; 
+	}
+	/**
+	 * 
+	 * @return true if a specific media log will be written.
+	 */
+	public boolean writeSpecificMediaLog()
+	{
+		return writeSpecificMediaLog; 
+	}	
 
 	/**
 	 * Tells COMETS to write a media log or not. See the COMETS documentation for format
@@ -1145,7 +1203,43 @@ public class FBAParameters implements PackageParameters
 	{
 		return mediaLogName; 
 	}
+	
+	/**
+	 * @param name
+	 * Sets the name of the specific media log file, if one is going to be written
+	 */
+	public void setSpecificMediaLogName(String name) { specificMediaLogName = name; }
+	
+	/**
+	 * @return the name of the specific media log file.
+	 */
+	public String getSpecificMediaLogName()
+	{
+		return specificMediaLogName; 
+	}
 
+	
+	/**
+	 * @param name 
+	 * Sets the string with the list of the specific media
+	 * these are a comma-separated string, e.g.
+	 * lcts[e],ac[e]
+	 */	
+	public void setSpecificMedia(String name){ 
+		// ideally, this would check at this moment to see if the media names in name 
+		// match those in c.getMediaNames().  However, those are not yet set, so this
+		// cannot be done.
+		specificMedia = name; 
+	} 
+	
+	/**
+	 * @return the string with the comma-separated list of specific media
+	 */
+	public String getSpecificMedia() 
+	{
+		return specificMedia; 
+	}
+	
 	/**
 	 * Sets the format of the media log file. Currently only supports either
 	 * MATLAB_FORMAT or COMETS_FORMAT, others are ignored.

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
@@ -430,7 +430,7 @@ public class FBAWorld extends World2D
 				print_string = print_string + mediaToPrintList[i] + "\t";
 			}
 			
-			String name = pParams.getSpecificMediaLogName();   
+			String name = adjustLogFileName(pParams.getSpecificMediaLogName(), timeStamp);
 			try{
 				specificMediaLogWriter = new PrintWriter(new FileWriter(new File(name)));
 				specificMediaLogWriter.println(print_string);

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
@@ -3155,6 +3155,9 @@ public class FBAWorld extends World2D
 		// 6. refresh media, if we're supposed to.
 		refreshMedia();
 		
+		// 7. apply metabolite dilution
+		applyMetaboliteDilution();
+		
 		if (!cParams.isCommandLineOnly())
 			updateInfoPanel();
 
@@ -3191,7 +3194,9 @@ public class FBAWorld extends World2D
 		}
 		
 		changeModelsInWorld(models, newModels);
-		setNumModels(newModels.length);		
+		setNumModels(newModels.length);
+		
+		
 		
 		currentTimePoint++;
 		if (pParams.writeFluxLog() && currentTimePoint % pParams.getFluxLogRate() == 0)


### PR DESCRIPTION
Hey Ilija, here's the pull request for the metaboliteDilutionRate and the specificMedia.

As discussed,
metaboliteDilutionRate is a parameter that affects all external metabolites (it is not implemented in a spatially-explicit way as of yet).  Setting the value between 0-1 will dilute a metabolite per unit time, similar to deathRate.  As a result, by combining this with an equal deathRate and a mediaRefresh, we can do a chemostat.

e.g. 

metaboliteDilutionRate=0.1   # removes 10% of each metabolite each hour

specificMedia introduces four new parameters. All together, it allows one to specify which metabolites to track.  That said, it currently always does per-box, i.e. it is not a "totalSpecificMedia" implementation.  That wouldn't be too hard for the future, however.  

e.g. 

writeSpecificMediaLog = true
specificMediaLogName = spec_media.txt
specificMediaLogRate = 10
specificMedia = ac[e],nh4[e],glc-D[e]

This set of parameters will track acetate, ammonia, and glucose every 10 time steps.  