### PR TITLE
media_refresh now per unit time, not per time step

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
@@ -875,8 +875,11 @@ public abstract class World2D implements CometsConstants, IWorld
 			double[] rpConc = new double[numMedia];
 			if (refreshPoints[x][y] != null)
 				rpConc = refreshPoints[x][y].getMediaRefresh();
-			for (int i=0; i<numMedia; i++)
+			for (int i=0; i<numMedia; i++){
+				System.out.println(rpConc[i]);
 				conc[i] = mediaRefresh[i] + rpConc[i];
+			}
+
 			return conc;
 		}
 		else

--- a/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
@@ -876,8 +876,9 @@ public abstract class World2D implements CometsConstants, IWorld
 			if (refreshPoints[x][y] != null)
 				rpConc = refreshPoints[x][y].getMediaRefresh();
 			for (int i=0; i<numMedia; i++){
-				System.out.println(rpConc[i]);
-				conc[i] = mediaRefresh[i] + rpConc[i];
+				// JMC something weird is up, figure this out
+				// this doesn't get called during loading of layout--must be called just by gui
+				conc[i] = mediaRefresh[i] + rpConc[i] * cParams.getTimeStep();
 			}
 
 			return conc;

--- a/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/World2D.java
@@ -876,9 +876,7 @@ public abstract class World2D implements CometsConstants, IWorld
 			if (refreshPoints[x][y] != null)
 				rpConc = refreshPoints[x][y].getMediaRefresh();
 			for (int i=0; i<numMedia; i++){
-				// JMC something weird is up, figure this out
-				// this doesn't get called during loading of layout--must be called just by gui
-				conc[i] = mediaRefresh[i] + rpConc[i] * cParams.getTimeStep();
+				conc[i] = mediaRefresh[i] + rpConc[i];
 			}
 
 			return conc;

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACometsLoader.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACometsLoader.java
@@ -1809,7 +1809,7 @@ public class FBACometsLoader implements CometsLoader, CometsConstants
 
 		for (int i=0; i<mediaRefresh.length; i++)
 		{
-			mediaRefresh[i] = Double.valueOf(header[i+1]);
+			mediaRefresh[i] = Double.valueOf(header[i+1]) * c.getParameters().getTimeStep();
 		}
 
 		for (String line : lines)
@@ -1827,7 +1827,7 @@ public class FBACometsLoader implements CometsLoader, CometsConstants
 			double[] refresh = new double[mediaRefresh.length];
 			for (int i=0; i<refresh.length; i++)
 			{
-				refresh[i] = Double.valueOf(refreshParsed[i+2]);
+				refresh[i] = Double.valueOf(refreshParsed[i+2]) * c.getParameters().getTimeStep();
 			}
 			refreshPoints.add(new RefreshPoint(Integer.valueOf(refreshParsed[0]), Integer.valueOf(refreshParsed[1]), refresh));
 		}

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAWorld.java
@@ -3214,11 +3214,12 @@ public class FBAWorld extends World2D
 		// 5. set static media
 		applyStaticMedia();
 		
+		// 7. apply metabolite dilution - this should go before media refresh, or else that will be diluted as well
+		applyMetaboliteDilution();
+		
 		// 6. refresh media, if we're supposed to.
 		refreshMedia();
 		
-		// 7. apply metabolite dilution
-		applyMetaboliteDilution();
 		
 		if (!cParams.isCommandLineOnly())
 			updateInfoPanel();


### PR DESCRIPTION
Basically I just added a * cParams.getTimeStep() in a couple of places.  This is handy because now media_refresh is in per unit time, which means we don't have to change it every time we change the timestep. 