### PR TITLE
Improving light modelling and fixing bug on exchange/media indexes

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -734,11 +734,21 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 					break;
 				
 			}
-
+			/***************** Calculate bounds for Light (photon) uptake **********/
+			double lightAbsSurfaceToWeight = ((FBAModel)models[i]).getLightAbsSurfaceToWeight();
+			double [] lightAbsorption = ((FBAModel)models[i]).getLightAbsorption();
+			for (int j=0; j<lb.length; j++)
+			{
+				if (lightAbsorption[j] > 0) {
+					rates[j] = Math.min(Math.abs(lb[j]), calcMaxLightUptake(media[j], biomass[i], cParams.getSpaceWidth()*cParams.getSpaceWidth(), lightAbsorption[j], lightAbsSurfaceToWeight));
+					System.out.println(rates[j]+ "\t"+ media[j]+ "\t"+ lightAbsSurfaceToWeight+ "\t"+ biomass[i]+"\t"+  cParams.getSpaceWidth());
+				}
+				lb[j] = -1 * rates[j]/rho;
+			}
+			
 			for (int j=0; j<lb.length; j++)
 			{
 				lb[j] = -1 * rates[j]/rho;
-;
 			}
 			if (DEBUG)
 			{
@@ -796,6 +806,12 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 				{	
 					mediaDelta[j] = (double)exchFlux[j] * biomass[i] * cParams.getTimeStep();
 //					System.out.print("\t" + exchFlux[j]);
+					if (lightAbsorption[j] > 0) {
+						// Light is not used up as this is a flux
+						mediaDelta[j] = 0;
+					}
+					else
+						mediaDelta[j] = (double)exchFlux[j] * biomass[i] * cParams.getTimeStep();
 				}
 				deltaMedia[i] = mediaDelta; // DJORDJE
 
@@ -882,6 +898,28 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 		for (int i=0; i<biomass.length; i++)
 			biomassShare[i] = biomass[i]/Utility.sum(biomass); 
 		return biomassShare;		
+	}
+
+	/**
+	 * Calculates the maximum light uptake.
+	 * This is determined by the minimum value of:
+	 * 1) The amount of light the organism can take up
+	 * 2) The amount of light entering the grid cell
+	 * @param lightFlux The "concentration" of photons i actually a flux [mmol photons/m^2/s]
+	 * @param biomass The total biomass in the grid cell of this organism [gDW]
+	 * @param gridSize The length scale of each grid in the cell [m]
+	 * @param absorption The absorption coefficient [unitless]
+	 * @param lightAbsSurfaceToWeight The ratio between the surface area absorbing photons and the dry weight [mm/gDW]
+	**/
+	private double calcMaxLightUptake(double lightFlux, double biomass, double gridArea, 
+									  double absorption, double lightAbsSurfaceToWeight)
+	{
+		// *3600 converts from per second to per hour
+		double maxLightRateOrganism = lightFlux*3600*lightAbsSurfaceToWeight*absorption;
+		// Grid area is the surface area of the grid cell, assuming sqaure grid cells
+		// The absolute maximum uptake rate of light is the total flux into the grid cell divided by the biomass 
+		double maxLightRateGrid = lightFlux*3600*gridArea/biomass;
+		return Math.min(maxLightRateOrganism, maxLightRateGrid);
 	}
 	/**
 	 * Updates the data owned by this FBACell. The fluxes are stored internally, while the

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
@@ -299,7 +299,8 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 		exchMetabNames = new String[numExch];
 		
 		int[] exch_tmp = exch.clone();
-		int cnt = 0;		
+		int cnt = 0;
+		
 		for (int i=0; i<m.length; i++)
 		{		
 			/* look for reaction in exch_tmp; if found, remove from exch_tmp 
@@ -2345,12 +2346,12 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 					if (numRxns <= 0)
 					{
 						reader.close();
-						throw new ModelFileException("The stoichiometric matrix should be loaded before the Hill coefficients at line " + lineNum);
+						throw new ModelFileException("The stoichiometric matrix should be loaded before the Light coefficients at line " + lineNum);
 					}
 					if (exchRxns == null)
 					{
 						reader.close();
-						throw new ModelFileException("The list of exchange reactions should be loaded before the Hill coefficients at line " + lineNum);
+						throw new ModelFileException("The list of exchange reactions should be loaded before the Light coefficients at line " + lineNum);
 					}
 					if (tokens.length != 2)
 					{

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
@@ -300,7 +300,7 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 		
 		int[] exch_tmp = exch.clone();
 		int cnt = 0;
-		
+
 		for (int i=0; i<m.length; i++)
 		{		
 			/* look for reaction in exch_tmp; if found, remove from exch_tmp 
@@ -314,12 +314,13 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 			{
 				int rxn = curr_rxn.intValue();
 				int mtb = curr_mtb.intValue();
-				ArrayUtils.removeElement(exch_tmp, rxn);
-				exchRxnNames[cnt] = rxnNames[rxn-1];
-				exchMetabNames[cnt] = metabNames[mtb-1];
+				// ArrayUtils.removeElement(exch_tmp, rxn);
+				exchRxnNames[is_exch] = rxnNames[rxn-1];
+				exchMetabNames[is_exch] = metabNames[mtb-1];
 				cnt++;
 			}				
 		}
+		
 		this.lightAbsorption = lightAbsorption;
 
 		baseExchLB = new double[numExch];

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAModel.java
@@ -117,7 +117,10 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 	private double[] exchAlpha;	  // another option for creating exchange reactions:
 	private double[] exchW; 		  // defined as min(alpha[i] * media[i], W[i] * volume) / biomass
 									  // not as "exact" as the kinetic constraints, but still time-independent
+	private double[] lightAbsorption; // Absorption coefficients (default 0), also used to know which metabolites / 
+									  // exchange reactions that take up light, because they have to be treated differently from normal metabolites 
 	
+	private double lightAbsSurfaceToWeight;
 	private double flowDiffConst; // = 1e-5;
 	private double growthDiffConst; // = 5e-5;
 	private double elasticModulusConst;
@@ -266,6 +269,7 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 					final double[] exchHillCoeff,
 					final double[] exchAlpha,
 					final double[] exchW,
+					final double[] lightAbsorption,
 					final String[] metabNames, 
 					final String[] rxnNames,
 					final int objStyle,
@@ -315,6 +319,7 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 				cnt++;
 			}				
 		}
+		this.lightAbsorption = lightAbsorption;
 
 		baseExchLB = new double[numExch];
 		baseExchUB = new double[numExch];
@@ -336,6 +341,9 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 	 * @param exchKm Michaelis constant of each exchange reaction
 	 * @param exchVmax Vmax for each exchange reaction (Michaelis-Menten style)
 	 * @param exchHillCoeff Hill coefficient for each exchange reaction (Monod style)
+	 * @param exchAlpha
+	 * @param exchW
+	 * @param lightAbsorption
 	 * @param metabNames array of metabolite names
 	 * @param rxnNames array of reaction names
 	 * @param optim optimizer
@@ -352,13 +360,17 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 					final double[] exchHillCoeff,
 					final double[] exchAlpha,
 					final double[] exchW,
+					final double[] lightAbsorption,
 					final String[] metabNames, 
 					final String[] rxnNames,
 					final int objStyle,
 					final int optim){
 		this(m,l,u,r,objMax,r[0],exch,exchDiffConsts,exchKm,exchVmax,exchHillCoeff,exchAlpha,
-				exchW,metabNames,rxnNames,objStyle,optim);
+				exchW,lightAbsorption,metabNames,rxnNames,objStyle,optim);
 	}
+
+
+	
 
 
 	public double getDefaultLB()
@@ -680,6 +692,49 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 		if (this.numExch == metabDiffConsts.length)
 			this.exchDiffConsts = metabDiffConsts;
 	}
+	
+////
+	/**
+	 * @return the light absorption coefficient for each exchange reaction
+	 */
+	public double[] getLightAbsorption()
+	{
+		return lightAbsorption;
+	}
+	
+	/**
+	 * 
+	 * @param i index of the exchange reaction
+	 * @return the light absorption coefficient for the specified reaction
+	 */
+	public double getLightAbsorption(int i) {
+		return lightAbsorption[i];
+	}
+	
+	public void setLightAbsorption(final double[] lightAbsorption)
+	{
+		if (this.numExch == lightAbsorption.length)
+			this.lightAbsorption = lightAbsorption;
+	}
+	
+	/**
+	 * 
+	 * @param lightAbsSurfaceToWeight The ratio between the light-absorbing surface and the dry weight of a cell 
+	 */
+	public void setLightAbsSurfaceToWeight(double lightAbsSurfaceToWeight)
+	{
+		this.lightAbsSurfaceToWeight = lightAbsSurfaceToWeight;
+	}
+	
+	/**
+	 * @return the light Light-absorbing surface-to-dry-weight ratio
+	 */
+	public double getLightAbsSurfaceToWeight()
+	{
+		return lightAbsSurfaceToWeight;
+	}
+	
+////
 	
 
 	/**
@@ -1230,6 +1285,7 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 			double[] exchKm = null;
 			double[] exchVmax = null;
 			double[] exchHillCoeff = null;
+			double[] lightAbsorption = null;
 			
 			double defaultAlpha = -1,
 				   defaultW = -1,
@@ -1244,7 +1300,8 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 				   convDiffConst=1,
 				   packDensity=1,
 				   noiseVariance=0.0,
-				   neutralDriftSigma=0.0;
+				   neutralDriftSigma=0.0,
+				   lightAbsSurfaceToWeight=1.0; // m^2/gDW
 			
 			boolean blockOpen = false;
 
@@ -2280,6 +2337,65 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 					}
 					
 				}
+				/**************************************************************
+				 ******************* LOAD LIGHT PARAMETERS *******************
+				 **************************************************************/
+				else if (tokens[0].equalsIgnoreCase("LIGHT"))
+				{
+					if (numRxns <= 0)
+					{
+						reader.close();
+						throw new ModelFileException("The stoichiometric matrix should be loaded before the Hill coefficients at line " + lineNum);
+					}
+					if (exchRxns == null)
+					{
+						reader.close();
+						throw new ModelFileException("The list of exchange reactions should be loaded before the Hill coefficients at line " + lineNum);
+					}
+					if (tokens.length != 2)
+					{
+						reader.close();
+						throw new ModelFileException("The LIGHT parameter at line " + lineNum + " should be followed by its surface to weight ratio in m^2 per gDW");
+					}
+					
+					lightAbsSurfaceToWeight = Double.parseDouble(tokens[1]);
+					lightAbsorption = new double[numExch];
+					for (int i=0; i<numExch; i++)
+						lightAbsorption[i] = 0;
+						
+					String lightLine = null;
+					blockOpen = true;
+					while (!(lightLine = reader.readLine().trim()).equalsIgnoreCase("//"))
+					{
+						lineNum++;
+						String[] parsed = lightLine.split("\\s+");
+						if (lightLine.length() == 0)
+							continue;
+						if (parsed.length != 2)
+						{
+							reader.close();
+							throw new ModelFileException("There should be 2 elements on each line of the LIGHT block at line " + lineNum + ": the exchange reaction index (from 1 to " + numExch + ") and the absorption coefficient of that reaction.");
+						}
+						
+						int rxn = Integer.parseInt(parsed[0]);
+						if (rxn < 1 || rxn > numExch)
+						{
+							reader.close();
+							throw new ModelFileException("The reaction index in LIGHT block line " + lineNum + " should be between 1 and " + numExch);
+						}
+						
+						double absorption = Double.parseDouble(parsed[1]);
+						if (absorption < 0 || absorption > 1)
+						{
+							reader.close();
+							throw new ModelFileException("The absorption value on line " + lineNum + " should be between 0 and 1");
+						}
+						
+						lightAbsorption[rxn-1] = absorption;
+					}
+					lineNum++;
+					blockOpen = false;
+				}
 			}
 			reader.close();
 			if (blockOpen)
@@ -2330,12 +2446,20 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 					exchW[i] = defaultW;
 			}
 			
+			if (lightAbsorption == null)
+			{
+				lightAbsorption = new double[numExch];
+				for (int i=0; i<numExch; i++)
+					lightAbsorption[i] = 0;
+				lightAbsSurfaceToWeight = 0;
+			}
+			
 		
 			if (bio == 0){ //if the Biomass reaction wasn't specified, use the primary Objective reaction
 				bio = objs[0];
 			}
 			
-			FBAModel model = new FBAModel(S, lb, ub, objs, objMax, bio, exchRxns, diffConsts, exchKm, exchVmax, exchHillCoeff, exchAlpha, exchW, metNames, rxnNames, objSt, optim);
+			FBAModel model = new FBAModel(S, lb, ub, objs, objMax, bio, exchRxns, diffConsts, exchKm, exchVmax, exchHillCoeff, exchAlpha, exchW, lightAbsorption, metNames, rxnNames, objSt, optim);
 			model.setDefaultAlpha(defaultAlpha);
 			model.setDefaultW(defaultW);
 			model.setDefaultHill(defaultHill);
@@ -2349,6 +2473,7 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 			model.setConvDiffConstant(convDiffConst);
 			model.setPackedDensity(packDensity);
 			model.setNoiseVariance(noiseVariance);
+			model.setLightAbsSurfaceToWeight(lightAbsSurfaceToWeight);
 			
 			model.setNeutralDrift(neutralDrift);
 			model.setNeutralDriftSigma(neutralDriftSigma);
@@ -2689,6 +2814,9 @@ public class FBAModel extends edu.bu.segrelab.comets.Model
 		modelCopy.setConvDiffConstant(getConvDiffConstant());
 		modelCopy.setPackedDensity(getPackedDensity());
 		modelCopy.setNoiseVariance(getNoiseVariance());
+		modelCopy.setLightAbsorption(getLightAbsorption());
+		modelCopy.setLightAbsSurfaceToWeight(getLightAbsSurfaceToWeight());
+		
 		//modelCopy.setParameters();
 		
 		return modelCopy;

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAPeriodicMedia.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAPeriodicMedia.java
@@ -4,6 +4,13 @@ package edu.bu.segrelab.comets.fba;
 //import java.lang.*;
 import java.util.Arrays;
 
+/**
+ * FBAPeriodicMedia
+ * -------------
+ * Defines the code for calculating periodic media conditions. Used primarily to calculate day/night cycle
+ *
+ * @author Snorre Sulheim snorre.sulheim@sintef.no
+ */
 public class FBAPeriodicMedia{
 	private int numCols;
 	private int numRows;


### PR DESCRIPTION
This should proably have been separated into two PR, but anyway.

1) Improved modelling of light
    Parameters related to light uptake are now read in from the model file. These parameters are:
    - Surface area to biomass dry weight ratio
    - Absorption coefficients. Note that there is still some work needed to refine the absorption coefficients.

2) Fixing bug in FBACell.
    When specific Vmax, Km, or now light conditions are set for specific exchange reactions in the    model the order of the exchange reactions makes a difference. This was not accounted for previously and this led to incorrect matching of reactions and coefficients (Vmax, Km, light)

