### PR TITLE
Signal bugfix

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/Comets.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/Comets.java
@@ -90,7 +90,7 @@ public class Comets implements CometsConstants,
 							   CometsChangeListener
 {
 
-	private String versionString = "2.10.1, 15 September 2020";
+	private String versionString = "2.10.2, 28 September 2020";
 
 	
 	/**

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -733,10 +733,6 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 			lb[i] = ((FBAModel)models[i]).getBaseExchLowerBounds();
 			ub[i] = ((FBAModel)models[i]).getBaseExchUpperBounds();
 			
-			String[] exchNames = ((FBAModel)models[i]).getExchangeReactionNames();
-
-			if (DEBUG)
-				System.out.println("Exchange reaction bounds:");
 			
 			// if a model has metabolite signal : reaction bound relationships,
 			// apply them
@@ -835,8 +831,8 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 		    //only set if the upper bound due to space constraints is lower than the default UB
 		    double bioub = (cParams.getMaxSpaceBiomass() - (Utility.sum(biomass) + Utility.sum(deltaBiomass))) / (biomass[i] * cParams.getTimeStep());
 			double currentbioub = ((FBAModel)models[i]).getUpperBounds()[((FBAModel)models[i]).getBiomassReaction() - 1];
-		    ((FBAModel)models[i]).setBiomassUpperBound(Math.min(currentbioub, bioub));
-			
+		    
+			((FBAModel)models[i]).setBiomassUpperBound(Math.min(currentbioub, bioub));
 			if (DEBUG)
 			{
 				System.out.println("ALL FLUX BOUNDS");
@@ -1018,7 +1014,7 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 					/************************* SET MAX BIOMASS *****************************/
 				    //only set if the upper bound due to space constraints is lower than the default UB
 				    double bioub = (cParams.getMaxSpaceBiomass() - (Utility.sum(biomass) + Utility.sum(deltaBiomass))) / (biomass[i] * cParams.getTimeStep());
-					double basebioub = ((FBAModel)models[i]).getBaseUpperBounds()[((FBAModel)models[i]).getBiomassReaction() - 1];
+					double basebioub = ((FBAModel)models[i]).getUpperBounds()[((FBAModel)models[i]).getBiomassReaction() - 1];
 				    ((FBAModel)models[i]).setBiomassUpperBound(Math.min(basebioub, bioub));
 					
 					if (DEBUG)

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -834,8 +834,8 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 			/************************* SET MAX BIOMASS *****************************/
 		    //only set if the upper bound due to space constraints is lower than the default UB
 		    double bioub = (cParams.getMaxSpaceBiomass() - (Utility.sum(biomass) + Utility.sum(deltaBiomass))) / (biomass[i] * cParams.getTimeStep());
-			double basebioub = ((FBAModel)models[i]).getBaseUpperBounds()[((FBAModel)models[i]).getBiomassReaction() - 1];
-		    ((FBAModel)models[i]).setBiomassUpperBound(Math.min(basebioub, bioub));
+			double currentbioub = ((FBAModel)models[i]).getUpperBounds()[((FBAModel)models[i]).getBiomassReaction() - 1];
+		    ((FBAModel)models[i]).setBiomassUpperBound(Math.min(currentbioub, bioub));
 			
 			if (DEBUG)
 			{

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACometsLoader.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACometsLoader.java
@@ -1091,7 +1091,6 @@ public class FBACometsLoader implements CometsLoader, CometsConstants
 		for (int i=0; i<tokens.length-1; i++)
 		{
 			String modelFileName = tokens[i+1];
-			System.out.println("Loading '" + modelFileName + "' ...");
 
 			//2-level testing.
 			// first, check to see if the file, as given, is real.

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAOptimizerGurobi.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBAOptimizerGurobi.java
@@ -680,6 +680,34 @@ implements edu.bu.segrelab.comets.CometsConstants
 						e.getMessage());
 			}
 		}
+		setLowerBoundsModelMin(nrxns, lb);
+		return PARAMS_OK;
+	}
+	
+	/**
+	 * Sets the array of lower bounds for all fluxes in the modelMin
+	 * Returns PARAMS_OK if number of reactions nrxns higher than zero,
+	 * MODEL_NOT_INITIALIZED if it is zero. This is called by
+	 * setLowerBounds()
+	 */	
+	public int setLowerBoundsModelMin(int nrxns, double[] lb)
+	{
+		if (nrxns == 0)
+		{
+			return MODEL_NOT_INITIALIZED;
+		}
+		for (int i = 0; i < nrxns; i++)
+		{
+			try{
+				modelMinVars[i].set(GRB.DoubleAttr.LB, lb[i]);
+			}
+			catch(GRBException e)
+			{
+				System.out.println("Error in FBAOptimizerGurobi.setLowerBoundsModelMin");
+				System.out.println("Error code: " + e.getErrorCode() + ". " +
+						e.getMessage());
+			}
+		}
 		return PARAMS_OK;
 	}
 
@@ -729,6 +757,35 @@ implements edu.bu.segrelab.comets.CometsConstants
 			catch(GRBException e)
 			{
 				System.out.println("Error in FBAOptimizerGurobi.setUpperBounds");
+				System.out.println("Error code: " + e.getErrorCode() + ". " +
+						e.getMessage());
+			}
+		}
+		setUpperBoundsModelMin(nrxns, ub);
+		return PARAMS_OK;
+	}
+	
+	/**
+	 * Sets the current upper bounds for the FBA problem in the modelMin
+	 * @param nrxns
+	 * @param ub upper bounds array
+	 * @return PARAMS_OK if the ub array is of the appropriate length,
+	 * MODEL_NOT_INITIALIZED if nrxns is zero.
+	 */
+	public int setUpperBoundsModelMin(int nrxns, double[] ub)
+	{
+		if (nrxns == 0)
+		{
+			return MODEL_NOT_INITIALIZED;
+		}
+		for (int i = 0; i < nrxns; i++)
+		{
+			try{
+				modelMinVars[i].set(GRB.DoubleAttr.UB, ub[i]);
+			}
+			catch(GRBException e)
+			{
+				System.out.println("Error in FBAOptimizerGurobi.setUpperBoundsModelMin");
 				System.out.println("Error code: " + e.getErrorCode() + ". " +
 						e.getMessage());
 			}


### PR DESCRIPTION
This commit fixed a couple of small bugs in signaling having to do with signals only sometimes working when max/min is set. As a part of the fix, it had the biomass upper bound compare the allowable amount in the current box to the value in getUpperBounds() rather than getBaseUpperBounds().  I think that should be fine for everything but we should be aware of the change in case there was a reason for using getBaseUpperBounds().