### PR TITLE
fixed off-by-one bug between signaling in comets and cometspy

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/Comets.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/Comets.java
@@ -92,7 +92,7 @@ public class Comets implements CometsConstants,
 							   CometsChangeListener
 {
 
-	private String versionString = "2.10.6, 20 May 2021";
+	private String versionString = "2.10.7, 26 Oct 2021";
 
 	
 	/**

--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/Signal.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/Signal.java
@@ -50,8 +50,11 @@ public class Signal {
 		this.lb = lb;
 		this.ub = ub;
 		this.consume_met = consume_met;
+		if (reaction != -1) {
+			reaction -= 1; // convert from 1-base to 0-base
+		}
 		this.reaction = reaction;
-		this.exch_met = exch_met - 1;  // don't ask me why this is off-by-one but not reaction!?!?
+		this.exch_met = exch_met - 1;  // because we let people write in terms of 1-base, but java is 0-order
 		this.function = function.toLowerCase();
 		
 		this.parameters = new ArrayList<>();


### PR DESCRIPTION
There was a bug in comets and also a bug in cometspy that "worked together" due to reciprocal off-by-one errors, but I'm fixing them both now. I will also push a new cometspy soon, and these versions should have each other as minimum version compatibilities (if one uses signaling). 