### PR TITLE
added linear production rate when lower bound > 0.0

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -749,6 +749,15 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 
 					for (int j=0; j<lb[i].length; j++)
 					{
+						
+						// Lowerbounds greater than 0.0 indicating forced production
+						// set rate linearly and skip michaelis-menten calculation
+						if (lb[i][j] > 0.0)
+						{
+							rates[j] = -lb[i][j];
+							continue;
+						}
+
 						double km = FBAParameters.getDefaultKm();
 						if (kmArr != null && kmArr.length > j && kmArr[j] > 0)
 							km = kmArr[j];
@@ -760,6 +769,8 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 							hill = hillCoeffArr[j];
 						
 						// Start of modified code corrected lb 9/19/13 Ilija D. updated by DJORDJE 
+						
+						// If mm is bigger than the (met_conc / biomass*timestep), rate = min(abs(lb), met_conc / biomass*timestep)
 						if(media[j]/(cParams.getTimeStep()*biomass[i])<calcMichaelisMentenRate(media[j]/(cParams.getSpaceVolume()), km, vMax, hill))
 						{
 							rates[j] = Math.min(Math.abs(lb[i][j]),Math.abs(media[j]/(cParams.getTimeStep()*biomass[i])));
@@ -780,6 +791,15 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 					
 					for (int j=0; j<lb[i].length; j++)
 					{
+
+						// Lowerbounds greater than 0.0 indicating forced production
+						// set rate linearly and skip michaelis-menten calculation
+						if (lb[i][j] > 0.0)
+						{
+							rates[j] = -lb[i][j];
+							continue;
+						}
+
 						double alpha = FBAParameters.getDefaultAlpha();
 						if (alphaArr != null && alphaArr.length > j && alphaArr[j] > 0)
 							alpha = alphaArr[j];
@@ -797,6 +817,15 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 				default :  // STANDARD_EXCHANGE
 					for (int j=0; j<lb[i].length; j++)
 					{
+
+						// Lowerbounds greater than 0.0 indicating forced production
+						// set rate linearly and skip michaelis-menten calculation
+						if (lb[i][j] > 0.0)
+						{
+							rates[j] = -lb[i][j];
+							continue;
+						}
+
 						rates[j] = Math.min(Math.abs(lb[i][j]),
 								Math.abs(calcStandardExchange(media[j])));
 								//Math.abs(calcStandardExchange(media[j]/(cParams.getSpaceVolume()))));


### PR DESCRIPTION
I've added a check statement to each of the exchange style cases to ensure a linear production if the lower bound is greater than 0.0. Previously, setting lower bounds > 0 could not be used to force metabolite production from a model.

# Example using Cobra e_coli 'text_book' model:
lower bound negative: e_coli.change_bounds("EX_glc__D_e", -1000, 1000)
lower bound zero: e_coli.change_bounds("EX_glc__D_e", 0.0, 1000)
lower bound positive: e_coli.change_bounds("EX_glc__D_e", 1.0, 1000)


## Previous behaviour
The image below shows the biomass of the three simulations (left) and the glucose concentrations (right). We have this unexpected growth when the lower bound is set to positive

We would expect to see growth only in the first instance, no growth in the second, and no growth or an error in the third.

![](https://user-images.githubusercontent.com/15074455/146060417-c6cc2a12-bc7f-4373-a19e-4fdb2a32440f.png)

## New behaviour
We now have growth only in when the lower bound is negative. Both negative lower bound and zero lower bound produce no growth. The negative lower bound produces an inviable solution (as expected), and the rates therefore revert to zero.
![Figure_2](https://user-images.githubusercontent.com/15074455/146921994-144008a6-4306-4118-bcd7-f854ab3def95.png)


