### PR TITLE
Implement safety check for metabolite index in FBACell.run

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -1218,6 +1218,12 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 				        	// Figure out the index of the metabolite in the lb vector
 				        	int[] modelMediaIndexes = world.getModelMediaIndexes(x, y, l);
 							int kIndexInModel = ArrayUtils.indexOf(modelMediaIndexes, k);
+
+							// SAFETY CHECK: skip if this metabolite is not mapped for this model
+							// or if the index is inconsistent with the LB array size
+							if (kIndexInModel < 0 || kIndexInModel >= lb[l].length) {
+    							continue;
+							}
 		
 							// update the lb 
 							lb[l][kIndexInModel] = -1*newUptake / (old_biomass[l] * cParams.getTimeStep());


### PR DESCRIPTION
This adds a bounds check on kIndexInModel in FBACell.run to avoid ArrayIndexOutOfBoundsException in multi-model simulations when some world media metabolites are not mapped for a given model.