### PR TITLE
Fix ArrayIndexOutOfBoundsException in FBACell for communities with unequal EX_ counts

### DIFF
--- a/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
+++ b/comets_simplified/src/edu/bu/segrelab/comets/fba/FBACell.java
@@ -1194,7 +1194,7 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 						int[] modelMediaIndexes = world.getModelMediaIndexes(x, y, l);
 						int kIndexInModel = ArrayUtils.indexOf(modelMediaIndexes, k);
 						//System.out.println(kIndexInModel);
-						if(kIndexInModel>-1)
+						if (kIndexInModel > -1 && kIndexInModel < deltaMedia[l].length)
 						{
 							totUptake += deltaMedia[l][kIndexInModel];
 							if (deltaMedia[l][kIndexInModel] < 0)
@@ -1214,16 +1214,23 @@ public class FBACell extends edu.bu.segrelab.comets.Cell
 				        {		        	
 				        	// Calculate new uptake by multiplying it by the fraction of the total
 	//			        	double newUptake = thisCellMedia[k] * (uptakeMat[l][k]/totUptake);
-				        	double newUptake = thisCellMedia[k] * (deltaMedia[l][k]/totUptake);			        	
-				        	// Figure out the index of the metabolite in the lb vector
+				        	// Translate the community-wide media index k into this model's own
+				        	// local exchange index. Community members can have different numbers
+				        	// of exchange reactions, so k must never be used to index a per-model
+				        	// array (deltaMedia[l], lb[l]) directly.
 				        	int[] modelMediaIndexes = world.getModelMediaIndexes(x, y, l);
-							int kIndexInModel = ArrayUtils.indexOf(modelMediaIndexes, k);
+				        	int kIndexInModel = ArrayUtils.indexOf(modelMediaIndexes, k);
 
-							// SAFETY CHECK: skip if this metabolite is not mapped for this model
-							// or if the index is inconsistent with the LB array size
-							if (kIndexInModel < 0 || kIndexInModel >= lb[l].length) {
-    							continue;
+							// SAFETY CHECK: skip if this metabolite is not one of this model's
+							// exchange reactions, or if the local index would fall outside this
+							// model's own arrays
+							if (kIndexInModel < 0 || kIndexInModel >= lb[l].length
+									|| kIndexInModel >= deltaMedia[l].length) {
+								continue;
 							}
+
+				        	// Calculate new uptake by multiplying it by the fraction of the total
+				        	double newUptake = thisCellMedia[k] * (deltaMedia[l][kIndexInModel]/totUptake);
 		
 							// update the lb 
 							lb[l][kIndexInModel] = -1*newUptake / (old_biomass[l] * cParams.getTimeStep());


### PR DESCRIPTION
## Problem

COMETS crashes with

```
ArrayIndexOutOfBoundsException: Index N out of bounds for length M
```

in multi-species layouts when community members have exchange-reaction
(`EX_`) arrays of different sizes. In our case: 4 organisms with 105 / 135
/ 138 / 159 exchange reactions; the reported index is always in that
105–159 range. The crash is intermittent because it only fires when the
"a metabolite is running out" branch is reached for a given
organism/metabolite pair in a given cycle.

## Root cause

In `FBACell.run()`, media-sharing block (around lines 1188–1230 on
`master`):

```java
for (Integer l : uptakingModels) {
    double newUptake = thisCellMedia[k] * (deltaMedia[l][k] / totUptake); // <-- here
    ...
    int kIndexInModel = ArrayUtils.indexOf(modelMediaIndexes, k);
    if (kIndexInModel < 0 || kIndexInModel >= lb[l].length) { continue; }
    lb[l][kIndexInModel] = ...;
}
```

`k` is the loop index over the **community-wide** media vector
(`thisCellMedia`, the union of every member's exchange metabolites).
`deltaMedia[l]` is a **per-model** array, sized to
`models[l].getExchangeFluxes().length`. When model `l` has fewer exchange
reactions than the shared media space, `deltaMedia[l][k]` reads out of
bounds. When `k` happens to land inside the array it silently uses the
wrong metabolite's delta.

The correct local index is `kIndexInModel =
ArrayUtils.indexOf(world.getModelMediaIndexes(x, y, l), k)`, which is
already computed a few lines later for the `lb[l]` write, and already used
correctly for the `deltaMedia[l][kIndexInModel]` read higher up in the
same method.

The safety check added in 8b07dcb ("Implement safety check for metabolite
index") only guards the `lb[l]` write; it does not cover the
`deltaMedia[l][k]` access on the `newUptake` line.

## Fix

- Compute `kIndexInModel` before it is used and index `deltaMedia[l]` with
  it instead of `k`.
- Extend the existing safety check with `kIndexInModel >=
  deltaMedia[l].length`.
- Add the same length guard to the earlier
  `deltaMedia[l][kIndexInModel]` read in the same block.

Behaviour is unchanged except that a community member simply does not
participate in the proportional-uptake rescaling for a metabolite it has
no exchange reaction for, which is the intended semantics.

## Testing

- `FBACell.java` compiles cleanly against the COMETS 2.12.3 API
  (`javac`, no errors).
- Reproduced on a 4-organism cross-feeding layout (exchange-reaction
  counts 105 / 135 / 138 / 159, `open_exchanges()` on all, co-located,
  `timeStep` 0.1 h). Our previous workaround was to pad every model's SBML
  with dummy `EX_` reactions so all members have equal-length exchange
  arrays; with the arrays left unequal:
  - **stock 2.12.3 jar:** crashes within the first cycles with
    `ArrayIndexOutOfBoundsException: Index 162 out of bounds for length 159`
    at `FBACell.java:1214` (same block as line 1217 on `master`).
  - **jar with this patch:** the same layout runs to completion
    (3360 cycles), no exception, biomass and media logs written normally.

Refs: issue on `ArrayIndexOutOfBoundsException` with unequal `EX_` array
sizes (Environment: COMETS 2.12.3 / 2.12.4 and current `master`).
